### PR TITLE
Add django-docker-template project

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,8 @@ Twitter feed: [twitter.com/AwesomeDjango](https://twitter.com/AwesomeDjango)
 * [edge](https://github.com/arocks/edge) - A Django project skeleton that is modern and cutting edge.
 * [demo-allauth-bootstrap](https://github.com/aellerton/demo-allauth-bootstrap) - Django sample app with users including social auth via Django-AllAuth.
 * [wemake-django-template](https://github.com/wemake-services/wemake-django-template) - Bleeding edge Django template focused on code quality and security.
-* [fuzzy-couscous](https://github.com/Tobi-De/fuzzy-couscous) - A cli tool to bootstrap your django projects and enhance your development experience. 
+* [fuzzy-couscous](https://github.com/Tobi-De/fuzzy-couscous) - A cli tool to bootstrap your django projects and enhance your development experience.
+* [django-docker-template](https://github.com/amerkurev/django-docker-template) - Dockerized Django with Postgres, Gunicorn, and Traefik (with auto renew Let's Encrypt) 
 
 ## Caching
 


### PR DESCRIPTION
Hello!

I've created a cool project template that you can use as a foundation for your future projects by simply copying it: https://github.com/amerkurev/django-docker-template

The main idea is to solve all deployment-related issues at the initial stage. In this project, everything is built in Docker, launched with Docker Compose, and Let's Encrypt certificate is automatically issued (you just need to have a domain). The certificate is also automatically renewed. It is configured through environment variables and described how to work in development mode and how to deploy to production.

But the most important thing is the minimalism of this project. It has nothing extra, it's easy to extend or modify.